### PR TITLE
Refine match phase event handling

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Match {
   goals: Goal[];
   substitutions: Substitution[];
   cards: Card[];
+  phaseEvents?: PhaseEvent[];
 }
 
 export interface PlayerGame {
@@ -72,6 +73,11 @@ export interface Card {
     foulType?: FoulType;
 }
 
+export interface PhaseEvent {
+  minute: number;
+  phase: 'start' | 'halftime' | 'secondHalf' | 'fulltime';
+}
+
 export type FirebaseUpdates = Record<string, unknown>;
 
 export type GoalType =
@@ -100,4 +106,5 @@ export type FoulType =
 export type TimelineItem =
   | { kind: 'goal'; minute: number; team: 'local' | 'visitor'; goal: Goal }
   | { kind: 'card'; minute: number; team: 'local' | 'visitor'; card: Card }
-  | { kind: 'sub'; minute: number; team: 'local' | 'visitor'; sub: Substitution };
+  | { kind: 'sub'; minute: number; team: 'local' | 'visitor'; sub: Substitution }
+  | { kind: 'phase'; minute: number; phase: 'start' | 'halftime' | 'secondHalf' | 'fulltime' };


### PR DESCRIPTION
## Summary
- merge recorded phase timestamps with sensible defaults so all match phases display
- validate and sort stored phase events while preventing empty or negative inputs
- remove leftover debug logging from match detail rendering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f6a19ce308321b9e442b679f590cf)