### PR TITLE
Move minute inputs to the start of add goal/card forms

### DIFF
--- a/src/components/cards-card.ts
+++ b/src/components/cards-card.ts
@@ -235,6 +235,17 @@ export class CardsCard extends LitElement {
         </div>
 
         <div class="add-card-form">
+          <md-filled-text-field
+            aria-label="Minuto de la tarjeta"
+            label="Minuto"
+            type="number"
+            inputmode="numeric"
+            id="cardMinute"
+            class="minute-input"
+            min="0"
+            max="90"
+            @change=${this._validateAddCard}
+          ></md-filled-text-field>
           <md-outlined-select
             id="cardTeam"
             aria-label="Equipo tarjeta"
@@ -263,17 +274,6 @@ export class CardsCard extends LitElement {
                 >`,
             )}
           </md-outlined-select>
-          <md-filled-text-field
-            aria-label="Minuto de la tarjeta"
-            label="Minuto"
-            type="number"
-            inputmode="numeric"
-            id="cardMinute"
-            class="minute-input"
-            min="0"
-            max="90"
-            @change=${this._validateAddCard}
-          ></md-filled-text-field>
           <md-filled-select
             id="cardType"
             aria-label="Tipo de tarjeta"

--- a/src/components/goals-card.ts
+++ b/src/components/goals-card.ts
@@ -253,6 +253,18 @@ export class GoalsCard extends LitElement {
           </div>
         </div>
         <div class="add-goal-form">
+          <md-filled-text-field
+            aria-label="Minuto del gol"
+            label="Minuto"
+            type="number"
+            inputmode="numeric"
+            id="newGoalMinute"
+            class="minute-input"
+            min="0"
+            max="90"
+            @change=${this._validateForm}
+            required
+          ></md-filled-text-field>
           <md-outlined-select
             id="goalTeam"
             aria-label="Equipo del gol"
@@ -292,18 +304,6 @@ export class GoalsCard extends LitElement {
                 >`,
             )}
           </md-outlined-select>
-          <md-filled-text-field
-            aria-label="Minuto del gol"
-            label="Minuto"
-            type="number"
-            inputmode="numeric"
-            id="newGoalMinute"
-            class="minute-input"
-            min="0"
-            max="90"
-            @change=${this._validateForm}
-            required
-          ></md-filled-text-field>
           <md-outlined-select
             id="newGoalType"
             aria-label="Tipo de gol"


### PR DESCRIPTION
### Motivation
- Improve the match-detail add forms UX by placing the minute input first in the "Agregar gol" and "Agregar tarjeta" sections so users can enter the minute immediately.

### Description
- Moved the `md-filled-text-field` for `newGoalMinute` to the top of the add-goal form in `src/components/goals-card.ts` and moved the `md-filled-text-field` for `cardMinute` to the top of the add-card form in `src/components/cards-card.ts`, preserving existing attributes and event handlers.

### Testing
- Ran an automated UI check with Playwright to load the app and capture a screenshot, but the Chromium browser crashed (`TargetClosedError` / SIGSEGV) so the automated UI check failed and no automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966da48b5748321a4105a2ebf9e3144)