### PR TITLE
Add iOS home screen icon metadata and web app manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
   <meta name="Description" content="Put your description here.">
   <base href="/">
   <link rel="icon" href="src/assets/images/favicon.png" type="image/png">
+  <link rel="apple-touch-icon" sizes="180x180" href="src/assets/images/favicon.png">
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="liga-mx-hrlv">
 
   <!-- Fonts & Material Symbols -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "liga-mx-hrlv",
+  "short_name": "liga-mx-hrlv",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ededed",
+  "theme_color": "#ededed",
+  "icons": [
+    {
+      "src": "src/assets/images/favicon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide iOS "Add to Home Screen" and PWA metadata so the app shows the app icon when users add it to their iPhone home screen.

### Description
- Added an `apple-touch-icon` link, PWA manifest link and iOS meta tags to `index.html`, and created `manifest.webmanifest` that references the existing `src/assets/images/favicon.png` as the app icon.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710d1fb0e88321bed98cfb91f745b8)