### PR TITLE
Mostrar tiempo agregado antes de tab y bloquear altas antes del inicio del partido

### DIFF
--- a/src/components/cards-card.ts
+++ b/src/components/cards-card.ts
@@ -22,11 +22,12 @@ import {
 } from '../types';
 import {
   buildCardEvent,
+  calculateSequenceForNewEvent,
   dispatchEventMatchUpdated,
   formatMatchMinute,
   getCardEvents,
+  getPhaseEvents,
   inferMatchPeriod,
-  calculateSequenceForNewEvent
 } from '../utils/functionUtils';
 
 @customElement('cards-card')
@@ -393,6 +394,7 @@ export class CardsCard extends LitElement {
               id="cardMinute"
               min="0"
               max="90"
+              @input=${this._validateAddCard}
               @change=${this._validateAddCard}
               required
             ></md-filled-text-field>
@@ -529,6 +531,7 @@ export class CardsCard extends LitElement {
             id="editCardMinute"
             min="0"
             max="90"
+            @input=${this._validateEditForm}
             @change=${this._validateEditForm}
             required
           ></md-filled-text-field>
@@ -695,6 +698,12 @@ export class CardsCard extends LitElement {
 
   private _addCard() {
     if (!this.match) return;
+    if (!this._hasMatchStarted()) {
+      globalThis.alert(
+        'Primero debes iniciar el partido para poder agregar tarjetas.',
+      );
+      return;
+    }
     const team = this.cardTeam;
     const player = Number(this.cardPlayerSelect.value);
     const minute = Number(this.cardMinuteInput.value);
@@ -864,6 +873,13 @@ export class CardsCard extends LitElement {
     return players;
   }
 
+  private _hasMatchStarted(): boolean {
+    if (!this.match) return false;
+    return getPhaseEvents(this.match.events || []).some(
+      event => event.phase === 'start',
+    );
+  }
+
   private _validateAddCard() {
     const team = this.cardTeam;
     const player = this.cardPlayerSelect?.value;
@@ -871,6 +887,7 @@ export class CardsCard extends LitElement {
     const type = this.cardTypeState;
     const foulType = this.cardFoulTypeSelect?.value;
     this.disableAddCard =
+      !this._hasMatchStarted() ||
       !team ||
       !player ||
       !minute ||

--- a/src/components/goals-card.ts
+++ b/src/components/goals-card.ts
@@ -28,6 +28,7 @@ import {
   dispatchEventMatchUpdated,
   formatMatchMinute,
   getGoalEvents,
+  getPhaseEvents,
   inferMatchPeriod,
 } from '../utils/functionUtils';
 @customElement('goals-card')
@@ -396,6 +397,7 @@ export class GoalsCard extends LitElement {
               id="newGoalMinute"
               min="0"
               max="90"
+              @input=${this._validateForm}
               @change=${this._validateForm}
               required
             ></md-filled-text-field>
@@ -508,15 +510,16 @@ export class GoalsCard extends LitElement {
             </label>
           </div>
 
-          <md-filled-text-field
-            label="Minuto"
-            type="number"
-            id="editGoalMinute"
-            min="0"
-            max="90"
-            @change=${this._validateEditForm}
-            required
-          ></md-filled-text-field>
+            <md-filled-text-field
+              label="Minuto"
+              type="number"
+              id="editGoalMinute"
+              min="0"
+              max="90"
+              @input=${this._validateEditForm}
+              @change=${this._validateEditForm}
+              required
+            ></md-filled-text-field>
 
           ${this.showEditAddedTime
             ? html`<md-filled-text-field
@@ -676,8 +679,21 @@ export class GoalsCard extends LitElement {
     );
   }
 
+  private _hasMatchStarted(): boolean {
+    if (!this.match) return false;
+    return getPhaseEvents(this.match.events || []).some(
+      event => event.phase === 'start',
+    );
+  }
+
   private _addGoal() {
     if (!this.match) return;
+    if (!this._hasMatchStarted()) {
+      globalThis.alert(
+        'Primero debes iniciar el partido para poder agregar goles.',
+      );
+      return;
+    }
     const team = this.goalTeamState as TeamSide;
     const player = Number(this.newGoalPlayerSelect.value);
     const minute = Number(this.newGoalMinuteInput.value);
@@ -771,6 +787,7 @@ export class GoalsCard extends LitElement {
     const goalType = this.newGoalTypeSelect?.value;
 
     this.disableAddGoalButton =
+      !this._hasMatchStarted() ||
       !selectedTeam ||
       !playerSelected ||
       !goalType ||

--- a/src/components/substitutions-card.ts
+++ b/src/components/substitutions-card.ts
@@ -19,11 +19,12 @@ import {
 } from '../types';
 import {
   buildSubstitutionEvent,
+  calculateSequenceForNewEvent,
   dispatchEventMatchUpdated,
   formatMatchMinute,
+  getPhaseEvents,
   getSubstitutionEvents,
   inferMatchPeriod,
-  calculateSequenceForNewEvent
 } from '../utils/functionUtils';
 
 @customElement('substitutions-card')
@@ -365,6 +366,7 @@ export class SubstitutionsCard extends LitElement {
               id="subMinute"
               min="0"
               max="90"
+              @input=${this._validateAddSub}
               @change=${this._validateAddSub}
             ></md-filled-text-field>
 
@@ -455,6 +457,7 @@ export class SubstitutionsCard extends LitElement {
             id="editSubMinute"
             min="0"
             max="90"
+            @input=${this._validateEditForm}
             @change=${this._validateEditForm}
           ></md-filled-text-field>
 
@@ -568,6 +571,12 @@ export class SubstitutionsCard extends LitElement {
 
   private _addSub() {
     if (!this.match) return;
+    if (!this._hasMatchStarted()) {
+      globalThis.alert(
+        'Primero debes iniciar el partido para poder agregar cambios.',
+      );
+      return;
+    }
     const team = this.subTeam;
     const playerOut = Number(this.subOutSelect.value);
     const playerIn = Number(this.subInSelect.value);
@@ -840,6 +849,7 @@ export class SubstitutionsCard extends LitElement {
     const playerIn = this.subInSelect?.value;
     const minute = this.subMinuteInput?.value;
     this.disableAddSub =
+      !this._hasMatchStarted() ||
       !team ||
       !playerOut ||
       !playerIn ||
@@ -854,5 +864,12 @@ export class SubstitutionsCard extends LitElement {
   private _onSubTeamChange() {
     this.requestUpdate();
     this._validateAddSub();
+  }
+
+  private _hasMatchStarted(): boolean {
+    if (!this.match) return false;
+    return getPhaseEvents(this.match.events || []).some(
+      event => event.phase === 'start',
+    );
   }
 }


### PR DESCRIPTION
### Motivation
- Permitir que al ingresar `45` o `90` en los campos de minuto el campo de `tiempo agregado` se renderice inmediatamente y pueda recibir el foco al tabular. 
- Evitar que se registren goles, tarjetas o cambios antes de que el partido haya comenzado (fase `start`).

### Description
- Añadí `@input` en los campos `Minuto` (alta y edición) en `goals-card`, `cards-card` y `substitutions-card` para que la aparición del campo de tiempo adicional ocurra mientras se escribe y antes de tabular. 
- Implementé `_hasMatchStarted()` en los tres componentes usando `getPhaseEvents(this.match.events).some(e => e.phase === 'start')` y la usé para deshabilitar los botones de alta y como guarda en ` _addGoal`, `_addCard` y `_addSub` con una `alert` informativa si se intenta agregar antes de iniciar. 
- Incorporé las comprobaciones de inicio de partido dentro de las validaciones (`disableAddGoalButton`, `disableAddCard`, `disableAddSub`) para bloquear la UI hasta que exista el evento de fase `start`. 
- Archivos modificados: `src/components/goals-card.ts`, `src/components/cards-card.ts`, `src/components/substitutions-card.ts`.

### Testing
- Ejecuté `npm run lint` y la tarea terminó correctamente (sin errores). 
- Ejecuté `npm run typecheck` (`tsc --noEmit`) y la verificación tipo pasó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c010fc91b883219fae718a9c7af11d)