### PR TITLE
Corregir persistencia del estadio al editar detalle de partido

### DIFF
--- a/src/pages/match-detail-page.ts
+++ b/src/pages/match-detail-page.ts
@@ -636,8 +636,12 @@ export class MatchDetailPage extends LitElement {
                 >
                   ${this.stadiums.map(
                     stadium =>
-                      html`<md-select-option value=${stadium}
-                        >${stadium}</md-select-option
+                      html`<md-select-option
+                        value="${stadium}"
+                        ?selected=${stadium === estadio}
+                      >
+                        <div slot="headline">${stadium}</div>
+                      </md-select-option
                       >`,
                   )}
                 </md-filled-select>
@@ -820,9 +824,17 @@ export class MatchDetailPage extends LitElement {
       fechaInput.value,
     );
     updates[`/matches/${this.match.idMatch}/hora`] = horaInput.value;
-    updates[`/matches/${this.match.idMatch}/estadio`] = estadioSelect.value;
+    updates[`/matches/${this.match.idMatch}/estadio`] =
+      this._getStadiumSelectValue(estadioSelect);
     this.dispatchEvent(dispatchEventMatchUpdated(updates));
     this.isEditing = false;
+  }
+
+  private _getStadiumSelectValue(estadioSelect: MdFilledSelect): string {
+    if (estadioSelect.value) return estadioSelect.value;
+    const selectedOption = estadioSelect.selectedOptions?.[0];
+    if (!selectedOption) return this.match?.estadio || '';
+    return selectedOption.value || selectedOption.textContent?.trim() || '';
   }
 
   private renderPhaseButton() {


### PR DESCRIPTION
### Motivation
- Al editar el estadio en el detalle del partido el valor no se estaba guardando porque el `md-filled-select` podía devolver `value` vacío y las opciones no estaban renderizadas con el contenido/estado esperado para Material Web.  

### Description
- Actualiza las opciones del select en `src/pages/match-detail-page.ts` para renderizar cada `md-select-option` con `slot="headline"` y `?selected=${stadium === estadio}` para asegurar que la UI muestre correctamente la opción seleccionada.  
- Reemplaza la lectura directa de `estadioSelect.value` al guardar por un helper `_getStadiumSelectValue` que devuelve `select.value`, o hace fallback a `selectedOptions[0]` o al `this.match.estadio` cuando corresponda.  
- Agrega la función privada `_getStadiumSelectValue(estadioSelect: MdFilledSelect): string` para centralizar la lógica de obtención del valor del estadio.  

### Testing
- Se ejecutó el linter sobre el archivo modificado con `npm run lint -- src/pages/match-detail-page.ts` y terminó correctamente (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc24a15888321ab02c67004833148)

Issue #543